### PR TITLE
[Lab 5] Added CLI support for TX monitoring

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -9264,5 +9264,28 @@ def motd(message):
                         {'motd': message})
 
 
+@config.command('tx_monitor_threshold')
+@click.argument('threshold', metavar='<threshold>', required=True, type=click.IntRange(0, 4294967295))
+def tx_monitor_threshold(threshold):
+    """
+    Set the threshold for tx monitoring agent
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_MONITOR_CONFIG_TABLE", 'tx_monitoring_config',
+                        {'tx_monitoring_threshold': threshold})
+
+@config.command('tx_monitor_time_period')
+@click.argument('time_period', metavar='<time_period>', required=True, type=click.IntRange(1, 4294967295))
+def tx_monitor_time_period(time_period):
+    """
+    Set the time period for tx monitoring agent
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_MONITOR_CONFIG_TABLE", 'tx_monitoring_config',
+                        {'tx_monitoring_time_period': time_period})
+
+
 if __name__ == '__main__':
     config()

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1157,3 +1157,21 @@ def dhcp_mitigation_rate(db, interfacename):
 
     header = ['Interface', 'DHCP Mitigation Rate']
     click.echo(tabulate(tablelize(keys), header, tablefmt="simple", stralign='left'))
+
+@interfaces.command()
+def tx_status():
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB)
+    keys_prefix = "TX_MONITOR_STATUS_TABLE|"
+    keys = state_db.keys(state_db.STATE_DB, keys_prefix + "*")
+    if not keys:
+        click.echo("TX status not found")
+        return
+    result = []
+    tx_monitoring_status_field = "tx_monitoring_status"
+    for key in natsorted(keys):
+        port_name = key.replace(keys_prefix, "")
+        port_result = [port_name]
+        port_result.append(state_db.get(state_db.STATE_DB, key, tx_monitoring_status_field))
+        result.append(port_result)
+    click.echo(tabulate(result, headers=["Port", "Tx Status"], tablefmt="grid"))


### PR DESCRIPTION
**What I did**
I added the following commands:

- **config tx_monitor_threshold [x]** - set the threshold of tx errors to x
- **config tx_monitor_time_period [x]** - set the period of TxMonitorOrch (doTask(Timer)) to x
- **show interfaces tx-status** - show the TX status of the interfaces (OK/NOT OK)

**How I did it**
I added new CLI commands to /show/interfaces/__init__.py and /config/main.py

**How to verify it**

1. Configure the TX monitoring threshold parameter - "config tx_monitor_threshold 10"
2. Configure the TX monitoring time_period parameter - "config tx_monitor_time_period 10"
3. Run "show interfaces tx-status" and verify the output is expected according to the TX counters

**Previous command output (if the output of a command-line utility has changed)**

**New command output (if the output of a command-line utility has changed)**